### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,28 +6,28 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SFE_HMC6343		KEYWORD1
+SFE_HMC6343	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-readMag			KEYWORD2
-readAccel		KEYWORD2
-readHeading		KEYWORD2
-readTilt		KEYWORD2
+readMag	KEYWORD2
+readAccel	KEYWORD2
+readHeading	KEYWORD2
+readTilt	KEYWORD2
 enterStandby	KEYWORD2
-exitStandby		KEYWORD2
-enterSleep		KEYWORD2
-exitSleep		KEYWORD2
+exitStandby	KEYWORD2
+enterSleep	KEYWORD2
+exitSleep	KEYWORD2
 enterCalMode	KEYWORD2
-exitCalMode		KEYWORD2
+exitCalMode	KEYWORD2
 setOrientation	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-LEVEL 		LITERAL1
-SIDEWAYS 	LITERAL1
+LEVEL	LITERAL1
+SIDEWAYS	LITERAL1
 FLATFRONT	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords