### PR TITLE
Add portability to 32-bit processors

### DIFF
--- a/src/SFE_HMC6343.cpp
+++ b/src/SFE_HMC6343.cpp
@@ -89,7 +89,7 @@ void SFE_HMC6343::readTilt()
 // Generic function which sends the HMC6343 a specified command
 // It then collects 6 bytes of data via I2C and consolidates it into three integers
 // whose addresses are passed to the function by the above read commands
-void SFE_HMC6343::readGeneric(uint8_t command, int* first, int* second, int* third)
+void SFE_HMC6343::readGeneric(uint8_t command, int16_t* first, int16_t* second, int16_t* third)
 {
   sendCommand(command); // Send specified I2C command to HMC6343
   delay(1); // Delay response time

--- a/src/SFE_HMC6343.h
+++ b/src/SFE_HMC6343.h
@@ -79,10 +79,10 @@ class SFE_HMC6343
   SFE_HMC6343();
   ~SFE_HMC6343();
   
-  int heading, pitch, roll;
-  int magX, magY, magZ;
-  int accelX, accelY, accelZ;
-  int temperature;
+  int16_t heading, pitch, roll;
+  int16_t magX, magY, magZ;
+  int16_t accelX, accelY, accelZ;
+  int16_t temperature;
   
   bool init();
   
@@ -116,7 +116,7 @@ class SFE_HMC6343
   void clearRawData();
   
   void sendCommand(uint8_t command);
-  void readGeneric(uint8_t command, int* first, int* second, int* third);
+  void readGeneric(uint8_t command, int16_t* first, int16_t* second, int16_t* third);
 };
 
 #endif


### PR DESCRIPTION
Tested on a Teensy 3.2

By specifying a 16-bit int, we ensure that 2's Complement signing will work on processors who's default int is 32 bits.  Before this change, the outputs presented as through 16-bit integer underflow was occurring, because within the 32-bit default int of the processor, it kind of was.